### PR TITLE
Drops explicit documentation formatting

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,3 @@
+# Overview
+
+::: egon_worker

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,9 +1,3 @@
----
-hide:
-- navigation
-- toc
----
-
 # egon_worker.cli
 
 ::: egon_worker.cli

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,0 @@
----
-hide:
-- navigation
-- toc
----
-
-egon_worker
-
-::: egon_worker

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,9 +1,3 @@
----
-hide:
-- navigation
-- toc
----
-
 # egon_worker.settings
 
 ::: egon_worker.settings

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,9 +1,3 @@
----
-hide:
-- navigation
-- toc
----
-
 # egon_worker.status
 
 ::: egon_worker.status

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -1,9 +1,3 @@
----
-hide:
-- navigation
-- toc
----
-
 # egon_worker.worker
 
 ::: egon_worker.worker


### PR DESCRIPTION
Removes explicit formatting directives from the Mkdocs markdown files. Moving forward, formatting will be handled by theming options in the [documentation](https://github.com/Egon-Framework/egon-framework.github.io) repository.